### PR TITLE
Move MIX_HOME and HEX_HOME outside of WORKDIR to facilate mounting volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Paul Schoenfelder <paulschoenfelder@gmail.com>
 # is updated with the current date. It will force refresh of all
 # of the base images and things like `apt-get update` won't be using
 # old cached versions when the Dockerfile is built.
-ENV REFRESHED_AT=2017-11-07 \
+ENV REFRESHED_AT=2017-11-20 \
     # Set this so that CTRL+G works properly
     TERM=xterm
 
@@ -23,6 +23,8 @@ RUN \
 
 # Add local node module binaries to PATH
 ENV PATH=./node_modules/.bin:$PATH \
+    MIX_HOME=/opt/mix \
+    HEX_HOME=/opt/hex \
     HOME=/opt/app
 
 # Install Hex+Rebar


### PR DESCRIPTION
@bitwalker: you're Elixir images and great, I use them all the time, both locally for development, and for production, so thanks!

That being said, leaving MIX_HOME and HEX_HOME at the default locations (/opt/app/.mix and /opt/app/.hex) causes all sorts of issues when trying to do local development in docker, and mounting source to /opt/app.  It ends up creating those directories outside the container and this can cause conflicts when trying to run the app outside of a container.

I currently set this env vars and reinstall hex and rebar manually, but I think making these changes to this image solves it for everyone.

Let me know what you think.