### PR TITLE
remove extra compilation in multistage build

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ COPY --from=phx-builder /opt/app/mix.* /opt/app/
 
 USER default
 
-CMD ["mix", "phx.server"]
+CMD ["mix", "phx.server", "--no-compile"]
 ```
 
 ## License


### PR DESCRIPTION
You can run phx.server without recompiling by adding `--no-compile` flag

https://hexdocs.pm/phoenix/Mix.Tasks.Phx.Server.html

Feel free to close if you feel it's not necessary.